### PR TITLE
Support php 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^8.3"
+        "php": "^8.2|^8.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",


### PR DESCRIPTION
Hi @brendt ! Thanks for this very useful package, I just saw your tweets and I'm happy to finally have a PHP highlighter :)
I want to use it on a PHP 8.2 KirbyCMS installation so I tried to fork it and modify it but one test is failing and I don't really understand why (maybe it's not passing in PHP 8.3 too ?) :

```bash
There was 1 failure:

1) Tempest\Highlight\Tests\RenderTokensTest::test_nested_tokens_c
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 '    <span class="hl-attribute">#[<span class="hl-type">get</span>(<span class="hl-property">hi</span>: '/')]</span>
-   <span class="hl-keyword">public</span>'
+   <span class="hl-keyword">public</span>c'

C:\Users\Benjamin\Development\100 - Git\forked-highlight\tests\RenderTokensTest.php:101

FAILURES!
Tests: 54, Assertions: 94, Failures: 1.
```