### PR TITLE
Add support for ```javascript

### DIFF
--- a/src/Highlighter.php
+++ b/src/Highlighter.php
@@ -37,6 +37,7 @@ final class Highlighter
             ->setLanguage('doc', new DocCommentLanguage())
             ->setLanguage('gdscript', new GdscriptLanguage())
             ->setLanguage('html', new HtmlLanguage())
+            ->setLanguage('javascript', new JavaScriptLanguage())
             ->setLanguage('js', new JavaScriptLanguage())
             ->setLanguage('json', new JsonLanguage())
             ->setLanguage('php', new PhpLanguage())


### PR DESCRIPTION
Just like for YAML, which supports both \`\`\`yaml and \`\`\`yml.