### PR TITLE
Added a shell script for highlighting on the console.

### DIFF
--- a/bin/tempest-highlight
+++ b/bin/tempest-highlight
@@ -1,0 +1,30 @@
+#!/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Tempest\Highlight\Highlighter;
+use Tempest\Highlight\Themes\LightTerminalTheme;
+
+
+require_once $_composer_autoload_path ?? __DIR__ . '/../vendor/autoload.php';
+
+stream_set_blocking(STDIN, false);
+$content = file_get_contents('php://stdin');
+
+if (empty($argv[1]) || (empty($content) && empty($argv[2]))) {
+    printf("Usage: %s: [language] '[content]'\n", basename(__FILE__));
+    exit(1);
+}
+
+$content = $content === '' ? $argv[2] : $content;
+$language = $argv[1];
+
+$thighlighter = new Highlighter(new LightTerminalTheme());
+
+if ($thighlighter->hasLanguage($language) === false) {
+    echo "Error: '$language' is not a currently supported language.\n";
+    exit(2);
+}
+
+echo $thighlighter->parse($content, strtolower($language)) . "\n";

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,6 @@
             "composer phpunit"
         ]
     },
-    "license": "MIT"
+    "license": "MIT",
+    "bin": ["bin/tempest-highlight"]
 }

--- a/src/Highlighter.php
+++ b/src/Highlighter.php
@@ -52,6 +52,11 @@ final class Highlighter
         }
     }
 
+    public function isSupportedLanguage(string $language): bool
+    {
+        return array_key_exists(strtolower($language), $this->languages);
+    }
+
     public function setLanguage(string $name, Language $language): self
     {
         $this->languages[$name] = $language;

--- a/src/Highlighter.php
+++ b/src/Highlighter.php
@@ -52,7 +52,7 @@ final class Highlighter
         }
     }
 
-    public function isSupportedLanguage(string $language): bool
+    public function hasLanguage(string $language): bool
     {
         return array_key_exists(strtolower($language), $this->languages);
     }

--- a/tests/ConsoleScriptTest.php
+++ b/tests/ConsoleScriptTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Highlight\Tests;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Tempest\Highlight\Highlighter;
+use Tempest\Highlight\Themes\LightTerminalTheme;
+
+class ConsoleScriptTest extends TestCase
+{
+    private function getHighlightCommand(): string
+    {
+        $commandPath = realpath(__DIR__ . '/../bin/tempest-highlight');
+
+        return "php '$commandPath'";
+    }
+
+    public function test_run_as_a_shell_script(): void
+    {
+        $expected = "Usage: tempest-highlight: [language] '[content]'";
+        exec($this->getHighlightCommand(), $actual, $resultCode);
+
+        Assert::assertEquals([$expected], $actual);
+        Assert::assertEquals(1, $resultCode);
+        ;
+    }
+
+    public function test_can_highlight_code_in_a_terminal_via_cli_args(): void
+    {
+        $code = <<<'PHP'
+        echo "Hello, World!!\n";
+        PHP;
+
+        $command = $this->getHighlightCommand() . ' PHP ' . escapeshellarg($code);
+        $actual = exec($command, $unused, $resultCode);
+
+        $expected = (new Highlighter(new LightTerminalTheme()))->parse($code, 'php');
+
+        Assert::assertEquals(0, $resultCode);
+        Assert::assertSame($expected, $actual);
+    }
+
+    public function test_supports_text_from_stdin_including_nowdoc(): void
+    {
+        $phpTest = function () {
+            $code = <<<'PHP'
+            for ($a = 6; $a > 0; --$a) {
+                echo "<h$a>Hello, PHP!</h$a>\n";
+            }
+            PHP;
+
+            $command = $this->getHighlightCommand();
+            $shellScript = <<<BASH
+            $command php <<'PHP'
+            {$code}
+            PHP
+            BASH;
+
+            exec($shellScript, $actual, $resultCode);
+            $actual = implode("\n", $actual);
+
+            $expected = (new Highlighter(new LightTerminalTheme()))->parse($code, 'php') . "\n";
+
+            Assert::assertEquals(0, $resultCode);
+            Assert::assertSame($expected, $actual);
+        };
+
+        $jsTest = function () {
+            $code = <<<'JS'
+            console.log('This is a multi-line coding sample.');
+            console.log('It is meant to test HERDOC-on-the-console support.');
+            JS;
+
+            $command = $this->getHighlightCommand();
+            $shellScript = <<<BASH
+            $command js <<'JS'
+            {$code}
+            JS
+            BASH;
+
+            exec($shellScript, $actual, $resultCode);
+            $actual = implode("\n", $actual);
+
+            $expected = (new Highlighter(new LightTerminalTheme()))->parse($code, 'javascript') . "\n";
+
+            Assert::assertEquals(0, $resultCode);
+            Assert::assertSame($expected, $actual);
+        };
+
+        $phpTest();
+        $jsTest();
+    }
+
+    public function test_will_fail_if_given_unsupported_language(): void
+    {
+        $command = $this->getHighlightCommand() . ' DOESNT_EXIST asdf';
+        exec($command, $output, $resultCode);
+
+        $expected = "Error: 'DOESNT_EXIST' is not a currently supported language.";
+        Assert::assertEquals(2, $resultCode);
+        Assert::assertEquals([$expected], $output);
+    }
+}

--- a/tests/ConsoleScriptTest.php
+++ b/tests/ConsoleScriptTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tempest\Highlight\Tests;
 
-use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Tempest\Highlight\Highlighter;
 use Tempest\Highlight\Themes\LightTerminalTheme;
@@ -23,8 +22,8 @@ class ConsoleScriptTest extends TestCase
         $expected = "Usage: tempest-highlight: [language] '[content]'";
         exec($this->getHighlightCommand(), $actual, $resultCode);
 
-        Assert::assertEquals([$expected], $actual);
-        Assert::assertEquals(1, $resultCode);
+        $this->assertEquals([$expected], $actual);
+        $this->assertEquals(1, $resultCode);
         ;
     }
 
@@ -39,8 +38,8 @@ class ConsoleScriptTest extends TestCase
 
         $expected = (new Highlighter(new LightTerminalTheme()))->parse($code, 'php');
 
-        Assert::assertEquals(0, $resultCode);
-        Assert::assertSame($expected, $actual);
+        $this->assertEquals(0, $resultCode);
+        $this->assertSame($expected, $actual);
     }
 
     public function test_supports_text_from_stdin_including_nowdoc(): void
@@ -64,8 +63,8 @@ class ConsoleScriptTest extends TestCase
 
             $expected = (new Highlighter(new LightTerminalTheme()))->parse($code, 'php') . "\n";
 
-            Assert::assertEquals(0, $resultCode);
-            Assert::assertSame($expected, $actual);
+            $this->assertEquals(0, $resultCode);
+            $this->assertSame($expected, $actual);
         };
 
         $jsTest = function () {
@@ -86,8 +85,8 @@ class ConsoleScriptTest extends TestCase
 
             $expected = (new Highlighter(new LightTerminalTheme()))->parse($code, 'javascript') . "\n";
 
-            Assert::assertEquals(0, $resultCode);
-            Assert::assertSame($expected, $actual);
+            $this->assertEquals(0, $resultCode);
+            $this->assertSame($expected, $actual);
         };
 
         $phpTest();
@@ -100,7 +99,7 @@ class ConsoleScriptTest extends TestCase
         exec($command, $output, $resultCode);
 
         $expected = "Error: 'DOESNT_EXIST' is not a currently supported language.";
-        Assert::assertEquals(2, $resultCode);
-        Assert::assertEquals([$expected], $output);
+        $this->assertEquals(2, $resultCode);
+        $this->assertEquals([$expected], $output);
     }
 }

--- a/tests/HighlighterTest.php
+++ b/tests/HighlighterTest.php
@@ -42,15 +42,15 @@ class HighlighterTest extends TestCase
         ];
     }
 
-    public function test_is_supported_language(): void
+    public function test_has_language(): void
     {
         $highlight = new Highlighter();
 
-        self::assertTrue($highlight->isSupportedLanguage('php'));
-        self::assertTrue($highlight->isSupportedLanguage('PHP'));
-        self::assertTrue($highlight->isSupportedLanguage('Php'));
+        self::assertTrue($highlight->hasLanguage('php'));
+        self::assertTrue($highlight->hasLanguage('PHP'));
+        self::assertTrue($highlight->hasLanguage('Php'));
 
-        self::assertFalse($highlight->isSupportedLanguage('DoesNotExist'));
-        self::assertFalse($highlight->isSupportedLanguage('DOESNOTEXIST'));
+        self::assertFalse($highlight->hasLanguage('DoesNotExist'));
+        self::assertFalse($highlight->hasLanguage('DOESNOTEXIST'));
     }
 }

--- a/tests/HighlighterTest.php
+++ b/tests/HighlighterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Highlight\Tests;
 
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -46,11 +47,11 @@ class HighlighterTest extends TestCase
     {
         $highlight = new Highlighter();
 
-        self::assertTrue($highlight->hasLanguage('php'));
-        self::assertTrue($highlight->hasLanguage('PHP'));
-        self::assertTrue($highlight->hasLanguage('Php'));
+        Assert::assertTrue($highlight->hasLanguage('php'));
+        Assert::assertTrue($highlight->hasLanguage('PHP'));
+        Assert::assertTrue($highlight->hasLanguage('Php'));
 
-        self::assertFalse($highlight->hasLanguage('DoesNotExist'));
-        self::assertFalse($highlight->hasLanguage('DOESNOTEXIST'));
+        Assert::assertFalse($highlight->hasLanguage('DoesNotExist'));
+        Assert::assertFalse($highlight->hasLanguage('DOESNOTEXIST'));
     }
 }

--- a/tests/HighlighterTest.php
+++ b/tests/HighlighterTest.php
@@ -41,4 +41,16 @@ class HighlighterTest extends TestCase
             ['02', 'html'], // deep injections
         ];
     }
+
+    public function test_is_supported_language(): void
+    {
+        $highlight = new Highlighter();
+
+        self::assertTrue($highlight->isSupportedLanguage('php'));
+        self::assertTrue($highlight->isSupportedLanguage('PHP'));
+        self::assertTrue($highlight->isSupportedLanguage('Php'));
+
+        self::assertFalse($highlight->isSupportedLanguage('DoesNotExist'));
+        self::assertFalse($highlight->isSupportedLanguage('DOESNOTEXIST'));
+    }
 }

--- a/tests/HighlighterTest.php
+++ b/tests/HighlighterTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tempest\Highlight\Tests;
 
-use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -47,11 +46,11 @@ class HighlighterTest extends TestCase
     {
         $highlight = new Highlighter();
 
-        Assert::assertTrue($highlight->hasLanguage('php'));
-        Assert::assertTrue($highlight->hasLanguage('PHP'));
-        Assert::assertTrue($highlight->hasLanguage('Php'));
+        $this->assertTrue($highlight->hasLanguage('php'));
+        $this->assertTrue($highlight->hasLanguage('PHP'));
+        $this->assertTrue($highlight->hasLanguage('Php'));
 
-        Assert::assertFalse($highlight->hasLanguage('DoesNotExist'));
-        Assert::assertFalse($highlight->hasLanguage('DOESNOTEXIST'));
+        $this->assertFalse($highlight->hasLanguage('DoesNotExist'));
+        $this->assertFalse($highlight->hasLanguage('DOESNOTEXIST'));
     }
 }


### PR DESCRIPTION
It originally required #84, but since that PR was basically rejected, I had to include the changes here, instead.

If `hasLanguage()` support really isn't needed, I will be more than happy to remove it.