### PR TITLE
Add prebuilt VSCode themes

### DIFF
--- a/src/Themes/andromeeda.css
+++ b/src/Themes/andromeeda.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #D5CED9;
+    background-color: #23262E;
+}
+
+.hl-keyword {
+    color: #c74ded;
+}
+
+.hl-property {
+    color: #FFE66D;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #96E072;
+}
+
+.hl-variable {
+    color: #00e8c6;
+}
+
+.hl-comment {
+    color: #A0A1A7cc;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/aurora-x.css
+++ b/src/Themes/aurora-x.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #000;
+    background-color: #07090F;
+}
+
+.hl-keyword {
+    color: #C792EA;
+}
+
+.hl-property {
+    color: #34A853;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #F78C6C;
+}
+
+.hl-value {
+    color: #C3E88D;
+}
+
+.hl-variable {
+    color: #EEFFFF;
+}
+
+.hl-comment {
+    color: #546E7A;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/ayu-dark.css
+++ b/src/Themes/ayu-dark.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #bfbdb6;
+    background-color: #0b0e14;
+}
+
+.hl-keyword {
+    color: #ff8f40;
+}
+
+.hl-property {
+    color: #34A853;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #d2a6ff;
+}
+
+.hl-value {
+    color: #aad94c;
+}
+
+.hl-variable {
+    color: #bfbdb6;
+}
+
+.hl-comment {
+    color: #acb6bf8c;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/catppuccin-frappe.css
+++ b/src/Themes/catppuccin-frappe.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #c6d0f5;
+    background-color: #303446;
+}
+
+.hl-keyword {
+    color: #ca9ee6;
+}
+
+.hl-property {
+    color: #8caaee;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #e5c890;
+}
+
+.hl-generic {
+    color: #e78284;
+}
+
+.hl-value {
+    color: #a6d189;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #737994;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/catppuccin-latte.css
+++ b/src/Themes/catppuccin-latte.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #4c4f69;
+    background-color: #eff1f5;
+}
+
+.hl-keyword {
+    color: #8839ef;
+}
+
+.hl-property {
+    color: #1e66f5;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #df8e1d;
+}
+
+.hl-generic {
+    color: #d20f39;
+}
+
+.hl-value {
+    color: #40a02b;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #9ca0b0;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/catppuccin-macchiato.css
+++ b/src/Themes/catppuccin-macchiato.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #cad3f5;
+    background-color: #24273a;
+}
+
+.hl-keyword {
+    color: #c6a0f6;
+}
+
+.hl-property {
+    color: #8aadf4;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #eed49f;
+}
+
+.hl-generic {
+    color: #ed8796;
+}
+
+.hl-value {
+    color: #a6da95;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #6e738d;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/catppuccin-mocha.css
+++ b/src/Themes/catppuccin-mocha.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #cdd6f4;
+    background-color: #1e1e2e;
+}
+
+.hl-keyword {
+    color: #cba6f7;
+}
+
+.hl-property {
+    color: #89b4fa;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #f9e2af;
+}
+
+.hl-generic {
+    color: #f38ba8;
+}
+
+.hl-value {
+    color: #a6e3a1;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #6c7086;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/dark-plus.css
+++ b/src/Themes/dark-plus.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #D4D4D4;
+    background-color: #1E1E1E;
+}
+
+.hl-keyword {
+    color: #569cd6;
+}
+
+.hl-property {
+    color: #DCDCAA;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #4EC9B0;
+}
+
+.hl-generic {
+    color: #569cd6;
+}
+
+.hl-value {
+    color: #ce9178;
+}
+
+.hl-variable {
+    color: #9CDCFE;
+}
+
+.hl-comment {
+    color: #6A9955;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/dracula-soft.css
+++ b/src/Themes/dracula-soft.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #f6f6f4;
+    background-color: #282A36;
+}
+
+.hl-keyword {
+    color: #f286c4;
+}
+
+.hl-property {
+    color: #62e884;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #97e1f1;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #e7ee98;
+}
+
+.hl-variable {
+    color: #f6f6f4;
+}
+
+.hl-comment {
+    color: #7b7f8b;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/dracula.css
+++ b/src/Themes/dracula.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #F8F8F2;
+    background-color: #282A36;
+}
+
+.hl-keyword {
+    color: #FF79C6;
+}
+
+.hl-property {
+    color: #50FA7B;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #8BE9FD;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #F1FA8C;
+}
+
+.hl-variable {
+    color: #F8F8F2;
+}
+
+.hl-comment {
+    color: #6272A4;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/github-dark-default.css
+++ b/src/Themes/github-dark-default.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #e6edf3;
+    background-color: #0d1117;
+}
+
+.hl-keyword {
+    color: #ff7b72;
+}
+
+.hl-property {
+    color: #d2a8ff;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #a5d6ff;
+}
+
+.hl-variable {
+    color: #ffa657;
+}
+
+.hl-comment {
+    color: #8b949e;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/github-dark-dimmed.css
+++ b/src/Themes/github-dark-dimmed.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #adbac7;
+    background-color: #22272e;
+}
+
+.hl-keyword {
+    color: #f47067;
+}
+
+.hl-property {
+    color: #dcbdfb;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #96d0ff;
+}
+
+.hl-variable {
+    color: #f69d50;
+}
+
+.hl-comment {
+    color: #768390;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/github-dark.css
+++ b/src/Themes/github-dark.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #e1e4e8;
+    background-color: #24292e;
+}
+
+.hl-keyword {
+    color: #f97583;
+}
+
+.hl-property {
+    color: #34A853;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #9ecbff;
+}
+
+.hl-variable {
+    color: #ffab70;
+}
+
+.hl-comment {
+    color: #6a737d;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/github-light-default.css
+++ b/src/Themes/github-light-default.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #1f2328;
+    background-color: #ffffff;
+}
+
+.hl-keyword {
+    color: #cf222e;
+}
+
+.hl-property {
+    color: #8250df;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #0a3069;
+}
+
+.hl-variable {
+    color: #953800;
+}
+
+.hl-comment {
+    color: #6e7781;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/github-light.css
+++ b/src/Themes/github-light.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #24292e;
+    background-color: #fff;
+}
+
+.hl-keyword {
+    color: #d73a49;
+}
+
+.hl-property {
+    color: #34A853;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #032f62;
+}
+
+.hl-variable {
+    color: #e36209;
+}
+
+.hl-comment {
+    color: #6a737d;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/houston.css
+++ b/src/Themes/houston.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #eef0f9;
+    background-color: #17191e;
+}
+
+.hl-keyword {
+    color: #54b9ff;
+}
+
+.hl-property {
+    color: #00daef;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #acafff;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #ffd493;
+}
+
+.hl-variable {
+    color: #4bf3c8;
+}
+
+.hl-comment {
+    color: #888888;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/light-plus.css
+++ b/src/Themes/light-plus.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #000000;
+    background-color: #FFFFFF;
+}
+
+.hl-keyword {
+    color: #0000ff;
+}
+
+.hl-property {
+    color: #795E26;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #267f99;
+}
+
+.hl-generic {
+    color: #0000ff;
+}
+
+.hl-value {
+    color: #a31515;
+}
+
+.hl-variable {
+    color: #001080;
+}
+
+.hl-comment {
+    color: #008000;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/material-theme-darker.css
+++ b/src/Themes/material-theme-darker.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #EEFFFF;
+    background-color: #212121;
+}
+
+.hl-keyword {
+    color: #4285F4;
+}
+
+.hl-property {
+    color: #82AAFF;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #C3E88D;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #545454;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/material-theme-lighter.css
+++ b/src/Themes/material-theme-lighter.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #90A4AE;
+    background-color: #FAFAFA;
+}
+
+.hl-keyword {
+    color: #4285F4;
+}
+
+.hl-property {
+    color: #6182B8;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #91B859;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #90A4AE;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/material-theme-ocean.css
+++ b/src/Themes/material-theme-ocean.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #babed8;
+    background-color: #0F111A;
+}
+
+.hl-keyword {
+    color: #4285F4;
+}
+
+.hl-property {
+    color: #82AAFF;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #C3E88D;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #464B5D;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/material-theme-palenight.css
+++ b/src/Themes/material-theme-palenight.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #babed8;
+    background-color: #292D3E;
+}
+
+.hl-keyword {
+    color: #4285F4;
+}
+
+.hl-property {
+    color: #82AAFF;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #C3E88D;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #676E95;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/material-theme.css
+++ b/src/Themes/material-theme.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #EEFFFF;
+    background-color: #263238;
+}
+
+.hl-keyword {
+    color: #4285F4;
+}
+
+.hl-property {
+    color: #82AAFF;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #C3E88D;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #546E7A;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/min-dark.css
+++ b/src/Themes/min-dark.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #000;
+    background-color: #1f1f1f;
+}
+
+.hl-keyword {
+    color: #f97583;
+}
+
+.hl-property {
+    color: #b392f0;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #79b8ff;
+}
+
+.hl-value {
+    color: #9db1c5;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #6b737c;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/min-light.css
+++ b/src/Themes/min-light.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #212121;
+    background-color: #ffffff;
+}
+
+.hl-keyword {
+    color: #D32F2F;
+}
+
+.hl-property {
+    color: #6f42c1;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #1976D2;
+}
+
+.hl-value {
+    color: #2b5581;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #c2c3c5;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/monokai.css
+++ b/src/Themes/monokai.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #f8f8f2;
+    background-color: #272822;
+}
+
+.hl-keyword {
+    color: #F92672;
+}
+
+.hl-property {
+    color: #A6E22E;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #AE81FF;
+}
+
+.hl-value {
+    color: #E6DB74;
+}
+
+.hl-variable {
+    color: #F8F8F2;
+}
+
+.hl-comment {
+    color: #88846f;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/night-owl.css
+++ b/src/Themes/night-owl.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #d6deeb;
+    background-color: #011627;
+}
+
+.hl-keyword {
+    color: #c792ea;
+}
+
+.hl-property {
+    color: #82AAFF;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #ffcb8b;
+}
+
+.hl-generic {
+    color: #82AAFF;
+}
+
+.hl-value {
+    color: #ecc48d;
+}
+
+.hl-variable {
+    color: #c5e478;
+}
+
+.hl-comment {
+    color: #637777;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/nord.css
+++ b/src/Themes/nord.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #d8dee9;
+    background-color: #2e3440;
+}
+
+.hl-keyword {
+    color: #81A1C1;
+}
+
+.hl-property {
+    color: #88C0D0;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #8FBCBB;
+}
+
+.hl-generic {
+    color: #81A1C1;
+}
+
+.hl-value {
+    color: #A3BE8C;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #616E88;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/one-dark-pro.css
+++ b/src/Themes/one-dark-pro.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #abb2bf;
+    background-color: #282c34;
+}
+
+.hl-keyword {
+    color: #c678dd;
+}
+
+.hl-property {
+    color: #61afef;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #e5c07b;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #98c379;
+}
+
+.hl-variable {
+    color: #e06c75;
+}
+
+.hl-comment {
+    color: #888888;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/poimandres.css
+++ b/src/Themes/poimandres.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #a6accd;
+    background-color: #1b1e28;
+}
+
+.hl-keyword {
+    color: #a6accd;
+}
+
+.hl-property {
+    color: #34A853;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #5DE4c7;
+}
+
+.hl-value {
+    color: #5DE4c7;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #767c9dB0;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/red.css
+++ b/src/Themes/red.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #F8F8F8;
+    background-color: #390000;
+}
+
+.hl-keyword {
+    color: #f12727ff;
+}
+
+.hl-property {
+    color: #34A853;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #cd8d8dff;
+}
+
+.hl-variable {
+    color: #fb9a4bff;
+}
+
+.hl-comment {
+    color: #e7c0c0ff;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/rose-pine-dawn.css
+++ b/src/Themes/rose-pine-dawn.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #575279;
+    background-color: #faf4ed;
+}
+
+.hl-keyword {
+    color: #286983;
+}
+
+.hl-property {
+    color: #34A853;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #d7827e;
+}
+
+.hl-value {
+    color: #ea9d34;
+}
+
+.hl-variable {
+    color: #d7827e;
+}
+
+.hl-comment {
+    color: #9893a5;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/rose-pine-moon.css
+++ b/src/Themes/rose-pine-moon.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #e0def4;
+    background-color: #232136;
+}
+
+.hl-keyword {
+    color: #3e8fb0;
+}
+
+.hl-property {
+    color: #34A853;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #ea9a97;
+}
+
+.hl-value {
+    color: #f6c177;
+}
+
+.hl-variable {
+    color: #ea9a97;
+}
+
+.hl-comment {
+    color: #6e6a86;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/rose-pine.css
+++ b/src/Themes/rose-pine.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #e0def4;
+    background-color: #191724;
+}
+
+.hl-keyword {
+    color: #31748f;
+}
+
+.hl-property {
+    color: #34A853;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #ebbcba;
+}
+
+.hl-value {
+    color: #f6c177;
+}
+
+.hl-variable {
+    color: #ebbcba;
+}
+
+.hl-comment {
+    color: #6e6a86;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/slack-dark.css
+++ b/src/Themes/slack-dark.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #E6E6E6;
+    background-color: #222222;
+}
+
+.hl-keyword {
+    color: #569cd6;
+}
+
+.hl-property {
+    color: #DCDCAA;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #4EC9B0;
+}
+
+.hl-generic {
+    color: #569cd6;
+}
+
+.hl-value {
+    color: #ce9178;
+}
+
+.hl-variable {
+    color: #9CDCFE;
+}
+
+.hl-comment {
+    color: #6A9955;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/slack-ochin.css
+++ b/src/Themes/slack-ochin.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #000;
+    background-color: #FFF;
+}
+
+.hl-keyword {
+    color: #7b30d0;
+}
+
+.hl-property {
+    color: #7eb233;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #1172c7;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #a44185;
+}
+
+.hl-variable {
+    color: #2f86d2;
+}
+
+.hl-comment {
+    color: #357b42;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/solarized-dark.css
+++ b/src/Themes/solarized-dark.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #839496;
+    background-color: #002B36;
+}
+
+.hl-keyword {
+    color: #859900;
+}
+
+.hl-property {
+    color: #268BD2;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #CB4B16;
+}
+
+.hl-generic {
+    color: #B58900;
+}
+
+.hl-value {
+    color: #2AA198;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #586E75;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/solarized-light.css
+++ b/src/Themes/solarized-light.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #657B83;
+    background-color: #FDF6E3;
+}
+
+.hl-keyword {
+    color: #859900;
+}
+
+.hl-property {
+    color: #268BD2;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #CB4B16;
+}
+
+.hl-generic {
+    color: #B58900;
+}
+
+.hl-value {
+    color: #2AA198;
+}
+
+.hl-variable {
+    color: #000;
+}
+
+.hl-comment {
+    color: #93A1A1;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/synthwave-84.css
+++ b/src/Themes/synthwave-84.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #000;
+    background-color: #262335;
+}
+
+.hl-keyword {
+    color: #fede5d;
+}
+
+.hl-property {
+    color: #36f9f6;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #f97e72;
+}
+
+.hl-value {
+    color: #000;
+}
+
+.hl-variable {
+    color: #ff7edb;
+}
+
+.hl-comment {
+    color: #848bbd;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/tokyo-night.css
+++ b/src/Themes/tokyo-night.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #a9b1d6;
+    background-color: #1a1b26;
+}
+
+.hl-keyword {
+    color: #bb9af7;
+}
+
+.hl-property {
+    color: #34A853;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #ff9e64;
+}
+
+.hl-value {
+    color: #9ece6a;
+}
+
+.hl-variable {
+    color: #c0caf5;
+}
+
+.hl-comment {
+    color: #51597d;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/vesper.css
+++ b/src/Themes/vesper.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #FFF;
+    background-color: #101010;
+}
+
+.hl-keyword {
+    color: #A0A0A0;
+}
+
+.hl-property {
+    color: #34A853;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #9d3af6;
+}
+
+.hl-value {
+    color: #99FFE4;
+}
+
+.hl-variable {
+    color: #FFF;
+}
+
+.hl-comment {
+    color: #8b8b8b94;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/vitesse-black.css
+++ b/src/Themes/vitesse-black.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #dbd7cacc;
+    background-color: #000;
+}
+
+.hl-keyword {
+    color: #4d9375;
+}
+
+.hl-property {
+    color: #80a665;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #4d9375;
+}
+
+.hl-value {
+    color: #c98a7d;
+}
+
+.hl-variable {
+    color: #bd976a;
+}
+
+.hl-comment {
+    color: #758575dd;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/vitesse-dark.css
+++ b/src/Themes/vitesse-dark.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #dbd7caee;
+    background-color: #121212;
+}
+
+.hl-keyword {
+    color: #4d9375;
+}
+
+.hl-property {
+    color: #80a665;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #4d9375;
+}
+
+.hl-value {
+    color: #c98a7d;
+}
+
+.hl-variable {
+    color: #bd976a;
+}
+
+.hl-comment {
+    color: #758575dd;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}

--- a/src/Themes/vitesse-light.css
+++ b/src/Themes/vitesse-light.css
@@ -1,0 +1,77 @@
+pre, code {
+    color: #393a34;
+    background-color: #ffffff;
+}
+
+.hl-keyword {
+    color: #1e754f;
+}
+
+.hl-property {
+    color: #59873a;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #EA4334;
+}
+
+.hl-generic {
+    color: #1e754f;
+}
+
+.hl-value {
+    color: #b56959;
+}
+
+.hl-variable {
+    color: #b07d48;
+}
+
+.hl-comment {
+    color: #a0ada0;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #00FF0022;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #FF000011;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #555;
+    padding: 0 1ch;
+}
+
+.hl-gutter-addition {
+    background-color: #34A853;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #EA4334;
+    color: #fff;
+}


### PR DESCRIPTION
Hi!

As discussed on X/Twitter https://twitter.com/djgeisi/status/1774771077173985694 this PR introduces 43 popular VSCode like themes for tempest/highlight.

## Background Infos
I wrote a script to extract the tempest/highlight relevant CSS properties from VsCode themes. This script is using a simple Mapping which looks like this:

```PHP
$tempestMapping = [
   'backgroundColor' => 'colors.editor.background',
   'commentColor' => 'tokenColors.comment.foreground',
   'textColor' => 'colors.editor.foreground',
   'keywordColor' => 'tokenColors.keyword.foreground',
   'propertyColor' => 'tokenColors.entity.name.function.foreground',
   'typeColor' => 'tokenColors.entity.name.class.foreground',
   'genericColor' => 'tokenColors.constant.language.foreground',
   'valueColor' => 'tokenColors.string.foreground',
   'variableColor' => 'tokenColors.variable.foreground',
];
```

I extracted the VSCode theme JSON files from here:

https://github.com/shikijs/textmate-grammars-themes/tree/main/packages/tm-themes

## Considerations

I placed the themes in the already existing themes folder. This folder gets a bit messy now, but I could not change the folder structure; it would have been a breaking change.

If you have a better idea, you're welcome.

Btw, it should be possible to extract the terminal themes from VsCode as well. This is not part of this PR, but when you are interested, I can give it a try.


