### PR TITLE
Adds data-lang attribute for CommonMark code block renderer

### DIFF
--- a/src/CommonMark/CodeBlockRenderer.php
+++ b/src/CommonMark/CodeBlockRenderer.php
@@ -38,7 +38,7 @@ final class CodeBlockRenderer implements NodeRendererInterface
         if ($theme instanceof WithPre) {
             return $theme->preBefore() . $parsed . $theme->preAfter();
         } else {
-            return '<pre>' . $parsed . '</pre>';
+            return '<pre data-lang="' . $matches['language'] . '">' . $parsed . '</pre>';
         }
     }
 }

--- a/tests/CommonMark/CodeBlockRendererTest.php
+++ b/tests/CommonMark/CodeBlockRendererTest.php
@@ -32,6 +32,7 @@ class CodeBlockRendererTest extends TestCase
         ```");
 
         $this->assertStringContainsString('hl-keyword', $parsed->getContent());
+        $this->assertStringContainsString('data-lang="php"', $parsed->getContent());
     }
 
     public function test_commonmark_with_gutter(): void
@@ -52,7 +53,7 @@ class Foo {}
 TXT;
 
         $expected = <<<'TXT'
-<pre><span class="hl-gutter ">10</span> <span class="hl-keyword">class</span> <span class="hl-type">Foo</span> {}</pre>
+<pre data-lang="php"><span class="hl-gutter ">10</span> <span class="hl-keyword">class</span> <span class="hl-type">Foo</span> {}</pre>
 
 TXT;
 


### PR DESCRIPTION
This PR adds a `data-lang` attribute to CommonMark `code` blocks, allowing an unobtrusive method of accessing the currently highlighted language for display purposes.

For example (in this case with Tailwind typography), the `prose-pre:after:content-[attr(data-lang)]` class could be used to style a pseudo element with the following result (top right):

<img width="753" alt="Screenshot 2024-04-02 at 16 46 40" src="https://github.com/tempestphp/highlight/assets/1692996/07447c28-bda3-44cc-9248-37c9b92aa8dc">

I've avoided adding this to `pre` output and `InlineTheme` output for simplicity, but happy to add this in if needed.