### PR TITLE
Fixed commonmark error when no language specified

### DIFF
--- a/src/CommonMark/CodeBlockRenderer.php
+++ b/src/CommonMark/CodeBlockRenderer.php
@@ -31,14 +31,16 @@ final class CodeBlockRenderer implements NodeRendererInterface
             $this->highlighter->withGutter((int)$startAt);
         }
 
-        $parsed = $this->highlighter->parse($node->getLiteral(), $matches['language']);
+        $language = $matches['language'] ?? 'txt';
+
+        $parsed = $this->highlighter->parse($node->getLiteral(), $language);
 
         $theme = $this->highlighter->getTheme();
 
         if ($theme instanceof WithPre) {
             return $theme->preBefore() . $parsed . $theme->preAfter();
         } else {
-            return '<pre data-lang="' . $matches['language'] . '">' . $parsed . '</pre>';
+            return '<pre data-lang="' . $language . '">' . $parsed . '</pre>';
         }
     }
 }

--- a/tests/CommonMark/CodeBlockRendererTest.php
+++ b/tests/CommonMark/CodeBlockRendererTest.php
@@ -86,4 +86,30 @@ TXT;
 
         $this->assertSame($expected, $markdown->convert($input)->getContent());
     }
+
+    public function test_commonmark_with_no_language(): void
+    {
+        $environment = new Environment();
+
+        $environment
+            ->addExtension(new CommonMarkCoreExtension())
+            ->addExtension(new FrontMatterExtension())
+            ->addRenderer(FencedCode::class, new CodeBlockRenderer());
+
+        $markdown = new MarkdownConverter($environment);
+
+        $input = <<<'TXT'
+```
+echo;
+```
+TXT;
+
+        $expected = <<<'TXT'
+<pre data-lang="txt">echo;
+</pre>
+
+TXT;
+
+        $this->assertSame($expected, $markdown->convert($input)->getContent());
+    }
 }


### PR DESCRIPTION
Fixes the issue described in https://github.com/tempestphp/highlight/issues/94

I've added a fallback to txt if no language is specified, which seems to be the convention used everywhere else.