### PR TITLE
Prevents Google translation

### DIFF
--- a/src/CommonMark/CodeBlockRenderer.php
+++ b/src/CommonMark/CodeBlockRenderer.php
@@ -42,7 +42,7 @@ final class CodeBlockRenderer implements NodeRendererInterface
         if ($theme instanceof WebTheme) {
             return $theme->preBefore($highlighter) . $parsed . $theme->preAfter($highlighter);
         } else {
-            return '<pre data-lang="' . $language . '">' . $parsed . '</pre>';
+            return '<pre data-lang="' . $language . '" class="notranslate">' . $parsed . '</pre>';
         }
     }
 }

--- a/src/Themes/CssTheme.php
+++ b/src/Themes/CssTheme.php
@@ -43,7 +43,7 @@ final readonly class CssTheme implements WebTheme
 
     public function preBefore(Highlighter $highlighter): string
     {
-        return "<pre data-lang=\"{$highlighter->getCurrentLanguage()->getName()}\">";
+        return "<pre data-lang=\"{$highlighter->getCurrentLanguage()->getName()}\" class=\"notranslate\">";
     }
 
     public function preAfter(Highlighter $highlighter): string

--- a/src/Themes/InlineTheme.php
+++ b/src/Themes/InlineTheme.php
@@ -73,7 +73,7 @@ final class InlineTheme implements Theme, WebTheme
     {
         $preStyle = $this->map['pre'] ?? $this->map['pre, code'] ?? '';
 
-        return "<pre data-lang=\"{$highlighter->getCurrentLanguage()->getName()}\" style=\"{$preStyle}\">";
+        return "<pre data-lang=\"{$highlighter->getCurrentLanguage()->getName()}\" class=\"notranslate\" style=\"{$preStyle}\">";
     }
 
     public function preAfter(Highlighter $highlighter): string


### PR DESCRIPTION
Hi Brent!

This package is used to render blocks of sample code on **spatie.be/docs**

Non-English users can translate the documentation using Google Translator if they want.

The inconvenience is that the code blocks are also translated. This is not necessary and looks ugly.

According to [Google instructions](https://cloud.google.com/translate/troubleshooting), setting `class="notranslate"` prevents Google translation.

For example, this is what GitHub does.