### PR TITLE
Use regex for gutterInjection line splitting

### DIFF
--- a/src/Languages/Base/Injections/GutterInjection.php
+++ b/src/Languages/Base/Injections/GutterInjection.php
@@ -34,7 +34,7 @@ final class GutterInjection implements Injection
 
     public function parse(string $content, Highlighter $highlighter): ParsedInjection
     {
-        $lines = explode(PHP_EOL, trim($content));
+        $lines = preg_split('/\R/', trim($content));
 
         $gutterNumbers = [];
         $longestGutterNumber = '';


### PR DESCRIPTION
Hi there @brendt, as mentioned on #104 I have a specific scenario where gutterInjection shows only on the first line (all other cases work as expected). It seems like the issue is the way you line splitting the content using `explode(PHP_EOL, $content)` as it has limited flexibility when handling all line break conventions correctly.

Given this I've switched to `preg_split('/\R/', trim($content))` which offers more versatility and flexibility, solving my specific scenario. From my testing, it should work in most environments and be a more reliable solution.