### PR TITLE
Addition/Deletion Injection Fixes

### DIFF
--- a/src/Languages/Base/Injections/AdditionInjection.php
+++ b/src/Languages/Base/Injections/AdditionInjection.php
@@ -15,6 +15,9 @@ final readonly class AdditionInjection implements Injection
 {
     public function parse(string $content, Highlighter $highlighter): ParsedInjection
     {
+        // Standardize line endings
+        $content = preg_replace("/(\r\n|\n|\r)/", PHP_EOL, $content);
+
         $content = str_replace('❷span class=❹ignore❹❸{+❷/span❸', '{+', $content);
         $content = str_replace('❷span class=❹ignore❹❸+}❷/span❸', '+}', $content);
 

--- a/src/Languages/Base/Injections/AdditionInjection.php
+++ b/src/Languages/Base/Injections/AdditionInjection.php
@@ -16,7 +16,7 @@ final readonly class AdditionInjection implements Injection
     public function parse(string $content, Highlighter $highlighter): ParsedInjection
     {
         // Standardize line endings
-        $content = preg_replace("/(\r\n|\n|\r)/", PHP_EOL, $content);
+        $content = preg_replace('/\R/', PHP_EOL, $content);
 
         $content = str_replace('❷span class=❹ignore❹❸{+❷/span❸', '{+', $content);
         $content = str_replace('❷span class=❹ignore❹❸+}❷/span❸', '+}', $content);

--- a/src/Languages/Base/Injections/DeletionInjection.php
+++ b/src/Languages/Base/Injections/DeletionInjection.php
@@ -15,6 +15,9 @@ final readonly class DeletionInjection implements Injection
 {
     public function parse(string $content, Highlighter $highlighter): ParsedInjection
     {
+        // Standardize line endings
+        $content = preg_replace("/(\r\n|\n|\r)/", PHP_EOL, $content);
+
         $content = str_replace('❷span class=❹ignore❹❸{-❷/span❸', '{-', $content);
         $content = str_replace('❷span class=❹ignore❹❸-}❷/span❸', '-}', $content);
 

--- a/src/Languages/Base/Injections/DeletionInjection.php
+++ b/src/Languages/Base/Injections/DeletionInjection.php
@@ -16,7 +16,7 @@ final readonly class DeletionInjection implements Injection
     public function parse(string $content, Highlighter $highlighter): ParsedInjection
     {
         // Standardize line endings
-        $content = preg_replace("/(\r\n|\n|\r)/", PHP_EOL, $content);
+        $content = preg_replace('/\R/', PHP_EOL, $content);
 
         $content = str_replace('❷span class=❹ignore❹❸{-❷/span❸', '{-', $content);
         $content = str_replace('❷span class=❹ignore❹❸-}❷/span❸', '-}', $content);

--- a/src/Languages/Base/Injections/GutterInjection.php
+++ b/src/Languages/Base/Injections/GutterInjection.php
@@ -58,7 +58,8 @@ final class GutterInjection implements Injection
         foreach ($lines as $i => $line) {
             $gutterNumber = $gutterNumbers[$i];
 
-            $gutterClass = 'hl-gutter ' . ($this->classes[$i + $this->startAt] ?? '');
+            $hasClasses = $this->classes[$i + $this->startAt] ?? '';
+            $gutterClass = 'hl-gutter' . ($hasClasses ? ' ' . $hasClasses : '');
 
             $lines[$i] = sprintf(
                 Escape::tokens('<span class="%s">%s</span> %s'),

--- a/src/Themes/InlineTheme.php
+++ b/src/Themes/InlineTheme.php
@@ -57,8 +57,8 @@ final class InlineTheme implements Theme, WebTheme
 
         $style = $this->map[".{$class}"] ?? null;
 
-        if (! $style) {
-            return '<span>';
+        if (!$style) {
+            return "<span class=\"{$class}\">";
         }
 
         return "<span style=\"{$style}\">";

--- a/src/Themes/InlineTheme.php
+++ b/src/Themes/InlineTheme.php
@@ -57,7 +57,7 @@ final class InlineTheme implements Theme, WebTheme
 
         $style = $this->map[".{$class}"] ?? null;
 
-        if (!$style) {
+        if (! $style) {
             return "<span class=\"{$class}\">";
         }
 

--- a/tests/CommonMark/CodeBlockRendererTest.php
+++ b/tests/CommonMark/CodeBlockRendererTest.php
@@ -53,7 +53,7 @@ class Foo {}
 TXT;
 
         $expected = <<<'TXT'
-<pre data-lang="php" class="notranslate"><span class="hl-gutter ">10</span> <span class="hl-keyword">class</span> <span class="hl-type">Foo</span> {}</pre>
+<pre data-lang="php" class="notranslate"><span class="hl-gutter">10</span> <span class="hl-keyword">class</span> <span class="hl-type">Foo</span> {}</pre>
 
 TXT;
 

--- a/tests/Languages/Base/Injections/GutterInjectionTest.php
+++ b/tests/Languages/Base/Injections/GutterInjectionTest.php
@@ -32,22 +32,22 @@ foreach ($lines as $i => $line) {
 TXT;
 
         $expected = <<<'TXT'
-<span class="hl-gutter ">  10</span> <span class="hl-keyword">foreach</span> (<span class="hl-variable">$lines</span> <span class="hl-keyword">as</span> <span class="hl-variable">$i</span> =&gt; <span class="hl-variable">$line</span>) {
-<span class="hl-gutter ">  11</span>     <span class="hl-variable">$gutterNumber</span> = <span class="hl-variable">$gutterNumbers</span>[<span class="hl-variable">$i</span>];
-<span class="hl-gutter ">  12</span> 
-<span class="hl-gutter ">  13</span>     <span class="hl-variable">$gutterClass</span> = '<span class="hl-value">hl-gutter </span>' . (<span class="hl-variable">$this</span>-&gt;<span class="hl-property">classes</span>[<span class="hl-variable">$i</span> + 1] ?? '<span class="hl-value"></span>');
+<span class="hl-gutter">  10</span> <span class="hl-keyword">foreach</span> (<span class="hl-variable">$lines</span> <span class="hl-keyword">as</span> <span class="hl-variable">$i</span> =&gt; <span class="hl-variable">$line</span>) {
+<span class="hl-gutter">  11</span>     <span class="hl-variable">$gutterNumber</span> = <span class="hl-variable">$gutterNumbers</span>[<span class="hl-variable">$i</span>];
+<span class="hl-gutter">  12</span> 
+<span class="hl-gutter">  13</span>     <span class="hl-variable">$gutterClass</span> = '<span class="hl-value">hl-gutter </span>' . (<span class="hl-variable">$this</span>-&gt;<span class="hl-property">classes</span>[<span class="hl-variable">$i</span> + 1] ?? '<span class="hl-value"></span>');
 <span class="hl-gutter hl-gutter-addition">14 +</span> <span class="hl-addition"></span>
 <span class="hl-gutter hl-gutter-addition">15 +</span> <span class="hl-addition">    <span class="hl-variable">$lines</span>[<span class="hl-variable">$i</span>] = <span class="hl-property">sprintf</span>(</span>
 <span class="hl-gutter hl-gutter-addition">16 +</span> <span class="hl-addition">        <span class="hl-type">Escape</span>::<span class="hl-property">tokens</span>('<span class="hl-value">&lt;span class=&quot;%s&quot;&gt;%s&lt;/span&gt;%s</span>'),</span>
-<span class="hl-gutter ">  17</span>         <span class="hl-variable">$gutterClass</span>,
-<span class="hl-gutter ">  18</span>         <span class="hl-property">str_pad</span>(
+<span class="hl-gutter">  17</span>         <span class="hl-variable">$gutterClass</span>,
+<span class="hl-gutter">  18</span>         <span class="hl-property">str_pad</span>(
 <span class="hl-gutter hl-gutter-deletion">19 -</span>             <span class="hl-property">string</span>: <span class="hl-deletion"><span class="hl-variable">$gutterNumber</span></span>,
-<span class="hl-gutter ">  20</span>             <span class="hl-property">length</span>: <span class="hl-variable">$gutterWidth</span>,
-<span class="hl-gutter ">  21</span>             <span class="hl-property">pad_type</span>: <span class="hl-property">STR_PAD_LEFT</span>,
-<span class="hl-gutter ">  22</span>         ),
-<span class="hl-gutter ">  23</span>         <span class="hl-variable">$line</span>,
-<span class="hl-gutter ">  24</span>     );
-<span class="hl-gutter ">  25</span> }
+<span class="hl-gutter">  20</span>             <span class="hl-property">length</span>: <span class="hl-variable">$gutterWidth</span>,
+<span class="hl-gutter">  21</span>             <span class="hl-property">pad_type</span>: <span class="hl-property">STR_PAD_LEFT</span>,
+<span class="hl-gutter">  22</span>         ),
+<span class="hl-gutter">  23</span>         <span class="hl-variable">$line</span>,
+<span class="hl-gutter">  24</span>     );
+<span class="hl-gutter">  25</span> }
 TXT;
         $highlighter = (new Highlighter())->withGutter(10);
 
@@ -65,11 +65,11 @@ other: foo
 TXT;
 
         $expected = <<<'TXT'
-<span class="hl-gutter ">  10</span> <span class="hl-property">on</span>:
-<span class="hl-gutter ">  11</span>   <span class="hl-property">pull_request</span>:
-<span class="hl-gutter ">  12</span>     <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review]
+<span class="hl-gutter">  10</span> <span class="hl-property">on</span>:
+<span class="hl-gutter">  11</span>   <span class="hl-property">pull_request</span>:
+<span class="hl-gutter">  12</span>     <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review]
 <span class="hl-gutter hl-gutter-addition">13 +</span> <span class="hl-addition"> <span class="hl-property">pull_request_target</span>: </span>
-<span class="hl-gutter ">  14</span> <span class="hl-property">other</span>: foo
+<span class="hl-gutter">  14</span> <span class="hl-property">other</span>: foo
 TXT;
 
         $highlighter = (new Highlighter())->withGutter(10);
@@ -91,14 +91,14 @@ other: foo
 TXT;
 
         $expected = <<<'TXT'
-<span class="hl-gutter ">  10</span> <span class="hl-property">on</span>:
-<span class="hl-gutter ">  11</span>   <span class="hl-property">pull_request</span>:
-<span class="hl-gutter ">  12</span>     <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review]
+<span class="hl-gutter">  10</span> <span class="hl-property">on</span>:
+<span class="hl-gutter">  11</span>   <span class="hl-property">pull_request</span>:
+<span class="hl-gutter">  12</span>     <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review]
 <span class="hl-gutter hl-gutter-addition">13 +</span> <span class="hl-addition"> <span class="hl-property">pull_request_target</span>: </span>
 <span class="hl-gutter hl-gutter-addition">14 +</span> <span class="hl-addition">   <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review] </span>
 <span class="hl-gutter hl-gutter-addition">15 +</span> <span class="hl-addition">   <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review] </span>
 <span class="hl-gutter hl-gutter-addition">16 +</span> <span class="hl-addition">   <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review] </span>
-<span class="hl-gutter ">  17</span> <span class="hl-property">other</span>: foo
+<span class="hl-gutter">  17</span> <span class="hl-property">other</span>: foo
 TXT;
 
         $highlighter = (new Highlighter())->withGutter(10);


### PR DESCRIPTION
Hi @brendt, this is a continuation of fixes presented in #104 where addition/deletion is not able to get the line endings correctly in my use case scenario, similar to #115 on the gutters it cannot read the current line thus applying it always on the first line.

What I did was standardize the line endings to EOL so it can be more flexible when handling line endings.

`$content = preg_replace("/(\r\n|\n|\r)/", PHP_EOL, $content);`

While I was debugging this I've notice that the `InlineTheme` is not getting the `IgnoreTokenType` for Addition/Deletion endings, being unable to replace them with '{-' and '-}'. So I've fixed it by returning the class when it's not found in the theme file instead of returning an empty span. This also return the classes of highlighting tags in case that are not present in the theme file.

In addition to the last PR, I've removed the spacing after `<span class="hl-gutter ">` if it does not follow by another class.

![image](https://github.com/tempestphp/highlight/assets/39380741/b6a13674-3d89-40bf-abfb-ae2e380bcf18)

Also if you could explain the use of `IgnoreTokenType`, disabling it even solves this InlineTheme problem and in all my testing I could not find any scenario that it's helping in any way, results being the same with or without. Probably it has a meaning, I was just wondering if it's really necessary or if we could find another solution.

P.S. Sorry for the unit-tests I always fucked them 😳