### PR TITLE
Add NUMBER and BOOLEAN tokens

### DIFF
--- a/src/Themes/CssTheme.php
+++ b/src/Themes/CssTheme.php
@@ -30,6 +30,7 @@ final readonly class CssTheme implements WebTheme
             TokenTypeEnum::INJECTION => 'hl-injection',
             TokenTypeEnum::VARIABLE => 'hl-variable',
             TokenTypeEnum::OPERATOR => 'hl-operator',
+            TokenTypeEnum::NUMBER => 'hl-number',
             default => $tokenType->getValue(),
         };
 

--- a/src/Themes/CssTheme.php
+++ b/src/Themes/CssTheme.php
@@ -21,17 +21,17 @@ final readonly class CssTheme implements WebTheme
 
         $class = match ($tokenType) {
             TokenTypeEnum::KEYWORD => 'hl-keyword',
-            TokenTypeEnum::PROPERTY => 'hl-property',
-            TokenTypeEnum::TYPE => 'hl-type',
-            TokenTypeEnum::GENERIC => 'hl-generic',
-            TokenTypeEnum::VALUE => 'hl-value',
-            TokenTypeEnum::COMMENT => 'hl-comment',
-            TokenTypeEnum::ATTRIBUTE => 'hl-attribute',
-            TokenTypeEnum::INJECTION => 'hl-injection',
             TokenTypeEnum::VARIABLE => 'hl-variable',
             TokenTypeEnum::OPERATOR => 'hl-operator',
+            TokenTypeEnum::TYPE => 'hl-type',
+            TokenTypeEnum::VALUE => 'hl-value',
             TokenTypeEnum::NUMBER => 'hl-number',
             TokenTypeEnum::BOOLEAN => 'hl-boolean',
+            TokenTypeEnum::PROPERTY => 'hl-property',
+            TokenTypeEnum::ATTRIBUTE => 'hl-attribute',
+            TokenTypeEnum::GENERIC => 'hl-generic',
+            TokenTypeEnum::COMMENT => 'hl-comment',
+            TokenTypeEnum::INJECTION => 'hl-injection',
             default => $tokenType->getValue(),
         };
 

--- a/src/Themes/CssTheme.php
+++ b/src/Themes/CssTheme.php
@@ -31,6 +31,7 @@ final readonly class CssTheme implements WebTheme
             TokenTypeEnum::VARIABLE => 'hl-variable',
             TokenTypeEnum::OPERATOR => 'hl-operator',
             TokenTypeEnum::NUMBER => 'hl-number',
+            TokenTypeEnum::BOOLEAN => 'hl-boolean',
             default => $tokenType->getValue(),
         };
 

--- a/src/Themes/InlineTheme.php
+++ b/src/Themes/InlineTheme.php
@@ -43,17 +43,17 @@ final class InlineTheme implements Theme, WebTheme
 
         $class = match ($tokenType) {
             TokenTypeEnum::KEYWORD => 'hl-keyword',
-            TokenTypeEnum::PROPERTY => 'hl-property',
-            TokenTypeEnum::TYPE => 'hl-type',
-            TokenTypeEnum::GENERIC => 'hl-generic',
-            TokenTypeEnum::VALUE => 'hl-value',
-            TokenTypeEnum::COMMENT => 'hl-comment',
-            TokenTypeEnum::ATTRIBUTE => 'hl-attribute',
-            TokenTypeEnum::INJECTION => 'hl-injection',
             TokenTypeEnum::VARIABLE => 'hl-variable',
             TokenTypeEnum::OPERATOR => 'hl-operator',
+            TokenTypeEnum::TYPE => 'hl-type',
+            TokenTypeEnum::VALUE => 'hl-value',
             TokenTypeEnum::NUMBER => 'hl-number',
             TokenTypeEnum::BOOLEAN => 'hl-boolean',
+            TokenTypeEnum::PROPERTY => 'hl-property',
+            TokenTypeEnum::ATTRIBUTE => 'hl-attribute',
+            TokenTypeEnum::GENERIC => 'hl-generic',
+            TokenTypeEnum::COMMENT => 'hl-comment',
+            TokenTypeEnum::INJECTION => 'hl-injection',
             default => $tokenType->getValue(),
         };
 

--- a/src/Themes/InlineTheme.php
+++ b/src/Themes/InlineTheme.php
@@ -53,6 +53,7 @@ final class InlineTheme implements Theme, WebTheme
             TokenTypeEnum::VARIABLE => 'hl-variable',
             TokenTypeEnum::OPERATOR => 'hl-operator',
             TokenTypeEnum::NUMBER => 'hl-number',
+            TokenTypeEnum::BOOLEAN => 'hl-boolean',
             default => $tokenType->getValue(),
         };
 

--- a/src/Themes/InlineTheme.php
+++ b/src/Themes/InlineTheme.php
@@ -52,6 +52,7 @@ final class InlineTheme implements Theme, WebTheme
             TokenTypeEnum::INJECTION => 'hl-injection',
             TokenTypeEnum::VARIABLE => 'hl-variable',
             TokenTypeEnum::OPERATOR => 'hl-operator',
+            TokenTypeEnum::NUMBER => 'hl-number',
             default => $tokenType->getValue(),
         };
 

--- a/src/Themes/LightTerminalTheme.php
+++ b/src/Themes/LightTerminalTheme.php
@@ -16,10 +16,12 @@ class LightTerminalTheme implements TerminalTheme
     {
         $style = match ($tokenType) {
             TokenTypeEnum::KEYWORD => TerminalStyle::FG_DARK_BLUE,
-            TokenTypeEnum::PROPERTY => TerminalStyle::FG_DARK_GREEN,
             TokenTypeEnum::TYPE => TerminalStyle::FG_DARK_RED,
-            TokenTypeEnum::GENERIC => TerminalStyle::FG_DARK_CYAN,
             TokenTypeEnum::VALUE => TerminalStyle::FG_BLACK,
+            TokenTypeEnum::NUMBER => TerminalStyle::FG_DARK_YELLOW,
+            TokenTypeEnum::BOOLEAN => TerminalStyle::FG_DARK_BLUE,
+            TokenTypeEnum::PROPERTY => TerminalStyle::FG_DARK_GREEN,
+            TokenTypeEnum::GENERIC => TerminalStyle::FG_DARK_CYAN,
             TokenTypeEnum::COMMENT => TerminalStyle::FG_GRAY,
             default => TerminalStyle::RESET,
         };

--- a/src/Tokens/TokenTypeEnum.php
+++ b/src/Tokens/TokenTypeEnum.php
@@ -7,17 +7,17 @@ namespace Tempest\Highlight\Tokens;
 enum TokenTypeEnum: string implements TokenType
 {
     case KEYWORD = 'keyword';
-    case PROPERTY = 'property';
-    case ATTRIBUTE = 'attribute';
-    case TYPE = 'type';
-    case GENERIC = 'generic';
-    case VALUE = 'value';
     case VARIABLE = 'variable';
-    case COMMENT = 'comment';
-    case INJECTION = 'injection';
     case OPERATOR = 'operator';
+    case TYPE = 'type';
+    case VALUE = 'value';
     case NUMBER = 'number';
     case BOOLEAN = 'boolean';
+    case PROPERTY = 'property';
+    case ATTRIBUTE = 'attribute';
+    case GENERIC = 'generic';
+    case COMMENT = 'comment';
+    case INJECTION = 'injection';
     case HIDDEN = 'hidden';
 
     public function getValue(): string

--- a/src/Tokens/TokenTypeEnum.php
+++ b/src/Tokens/TokenTypeEnum.php
@@ -17,6 +17,7 @@ enum TokenTypeEnum: string implements TokenType
     case INJECTION = 'injection';
     case OPERATOR = 'operator';
     case NUMBER = 'number';
+    case BOOLEAN = 'boolean';
     case HIDDEN = 'hidden';
 
     public function getValue(): string

--- a/src/Tokens/TokenTypeEnum.php
+++ b/src/Tokens/TokenTypeEnum.php
@@ -16,6 +16,7 @@ enum TokenTypeEnum: string implements TokenType
     case COMMENT = 'comment';
     case INJECTION = 'injection';
     case OPERATOR = 'operator';
+    case NUMBER = 'number';
     case HIDDEN = 'hidden';
 
     public function getValue(): string


### PR DESCRIPTION
Hey @brendt, I know you said in #96 that you don't plan on adding new tokens so this might be pointless.

But I'm still taking my shoot on implementing `NUMBER` and `BOOLEAN` tokens because:

- they are an important part of syntax highlighting and deserve their own tokens
- most themes handle them differently, making it impossible to highlight them correctly on multi-theme setup

If approved, I'm happy to do another PR on updating the themes/classes with these new tokens.
