### PR TITLE
Support unicode tokens in standardizing line endings

### DIFF
--- a/src/Languages/Base/Injections/AdditionInjection.php
+++ b/src/Languages/Base/Injections/AdditionInjection.php
@@ -16,7 +16,7 @@ final readonly class AdditionInjection implements Injection
     public function parse(string $content, Highlighter $highlighter): ParsedInjection
     {
         // Standardize line endings
-        $content = preg_replace('/\R/', PHP_EOL, $content);
+        $content = preg_replace('/\R/u', PHP_EOL, $content);
 
         $content = str_replace('❷span class=❹ignore❹❸{+❷/span❸', '{+', $content);
         $content = str_replace('❷span class=❹ignore❹❸+}❷/span❸', '+}', $content);

--- a/src/Languages/Base/Injections/DeletionInjection.php
+++ b/src/Languages/Base/Injections/DeletionInjection.php
@@ -16,7 +16,7 @@ final readonly class DeletionInjection implements Injection
     public function parse(string $content, Highlighter $highlighter): ParsedInjection
     {
         // Standardize line endings
-        $content = preg_replace('/\R/', PHP_EOL, $content);
+        $content = preg_replace('/\R/u', PHP_EOL, $content);
 
         $content = str_replace('❷span class=❹ignore❹❸{-❷/span❸', '{-', $content);
         $content = str_replace('❷span class=❹ignore❹❸-}❷/span❸', '-}', $content);


### PR DESCRIPTION
This PR fixes rendering codes that contain UTF-8 tokens. For example, the following code is not currently being rendered correctly:

```python
نام_پنجره = turtle.Screen()
```

The highlighted output is currently something like this:

<img width="541" alt="Screenshot 1403-05-13 at 11 10 55" src="https://github.com/user-attachments/assets/81d126e4-bc04-4cee-bbb4-0e3d4e12c018">

This PR uses the regular expression `u` flag to support Unicode characters. The result is now correct:

<img width="606" alt="Screenshot 1403-05-13 at 11 12 40" src="https://github.com/user-attachments/assets/68839390-de57-40a9-affb-72b7c6fec984">