### PR TITLE
Replace `larapack/dd` with `symfony/var-dumper`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "phpstan/phpstan": "^1.10.0",
         "friendsofphp/php-cs-fixer": "^3.21",
         "league/commonmark": "^2.4",
-        "larapack/dd": "^1.1",
-        "assertchris/ellison": "^1.0.2"
+        "assertchris/ellison": "^1.0.2",
+        "symfony/var-dumper": "^6.4|^7.0"
     },
     "suggest": {
         "assertchris/ellison": "Allows you to analyse sentence complexity",


### PR DESCRIPTION
`larapack/dd` no longer provides any value, because now `symfony/var-dumper` ships `dd` and `dump` helpers on its own.

I set the version to `"^6.4|^7.0"`, but lmk if you think another option would be more suitable.