### PR TITLE
Add "Inspired GitHub" theme

### DIFF
--- a/src/Themes/Css/inspired-github.css
+++ b/src/Themes/Css/inspired-github.css
@@ -1,0 +1,95 @@
+pre, code {
+    color: #323232;
+    background-color: #ffffff;
+}
+
+.hl-keyword {
+    color: #a71d5d;
+    font-weight: bold;
+}
+
+.hl-property {
+    color: #795da3;
+}
+
+.hl-attribute {
+    font-style: italic;
+}
+
+.hl-type {
+    color: #0086b3;
+}
+
+.hl-generic {
+    color: #795da3;
+}
+
+.hl-number,
+.hl-literal,
+.hl-value {
+    color: #0086b3;
+}
+
+.hl-variable {
+    color: #323232;
+}
+
+.hl-comment {
+    color: #969896;
+    font-style: italic;
+}
+
+.hl-string {
+    color: #183691;
+}
+
+.hl-function-name {
+    color: #795da3;
+    font-weight: bold;
+}
+
+.hl-tag {
+    color: #63a35c;
+}
+
+.hl-blur {
+    filter: blur(2px);
+}
+
+.hl-strong {
+    font-weight: bold;
+}
+
+.hl-em {
+    font-style: italic;
+}
+
+.hl-addition {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #eaffea;
+}
+
+.hl-deletion {
+    display: inline-block;
+    min-width: 100%;
+    background-color: #ffecec;
+}
+
+.hl-gutter {
+    display: inline-block;
+    font-size: 0.9em;
+    color: #b3b3b3;
+    padding: 0 1ch;
+    user-select: none;
+}
+
+.hl-gutter-addition {
+    background-color: #55a532;
+    color: #fff;
+}
+
+.hl-gutter-deletion {
+    background-color: #bd2c00;
+    color: #fff;
+}


### PR DESCRIPTION
This is the theme Taylor Otwell and Nuno Maduro use[[1](https://youtu.be/1P3wLy49t2c), [2](https://youtu.be/lEvau6CgqPE)] in light mode on Sublime Text.

Originally from here: https://packagecontrol.io/packages/Inspired%20GitHub%20Color%20Scheme

Also, In Sublime Text this theme shows different colours for HTML/XML/Blade/Twig compared to programming languages, but it's hard to get it done correctly with CSS selectors as there isn't a way to distinguish Blade tags from regular HTML keywords in Tempest as of right now.

### Original

<img width="1427" alt="image" src="https://github.com/user-attachments/assets/d2bec360-91ea-46bd-85a6-5fee00df22d5">

### Current implementation demo

<img width="730" alt="image" src="https://github.com/user-attachments/assets/77c242e7-bd53-43be-9ea1-9b9e3f6911ef">

<img width="1016" alt="image" src="https://github.com/user-attachments/assets/a5a87296-cc05-4ead-9b65-05380ced247f">
