### PR TITLE
Support unicode tokens in standardizing line endings

### DIFF
--- a/src/Languages/Base/Injections/GutterInjection.php
+++ b/src/Languages/Base/Injections/GutterInjection.php
@@ -34,7 +34,7 @@ final class GutterInjection implements Injection
 
     public function parse(string $content, Highlighter $highlighter): ParsedInjection
     {
-        $lines = preg_split('/\R/', trim($content));
+        $lines = preg_split('/\R/u', trim($content));
 
         $gutterNumbers = [];
         $longestGutterNumber = '';

--- a/src/Languages/Ellison/Injections/ParserInjection.php
+++ b/src/Languages/Ellison/Injections/ParserInjection.php
@@ -23,7 +23,7 @@ final readonly class ParserInjection implements Injection
     {
         $ellison = new Ellison();
         $parsed = [];
-        $paragraphs = preg_split('/\R/', trim($content));
+        $paragraphs = preg_split('/\R/u', trim($content));
 
         foreach ($paragraphs as $paragraph) {
             $parsedParagraph = '';


### PR DESCRIPTION
This PR fixes rendering codes that contain UTF-8 tokens when using gutter or Ellison. For example, the following code is not currently being rendered correctly:

```python
import نام کتابخانه
```

The highlighted output is currently something like this:

<img width="412" alt="Screenshot 1403-06-05 at 11 20 43" src="https://github.com/user-attachments/assets/b49fd4db-4df4-43aa-b613-2795bcc14a2e">

This PR uses the regular expression `u` flag to support Unicode characters. The result is now correct:

<img width="595" alt="Screenshot 1403-06-05 at 11 23 47" src="https://github.com/user-attachments/assets/95f735bf-d07f-4a4e-881d-a430a516e52c">