### PR TITLE
Fix for extra added spaces at the start of lines

### DIFF
--- a/src/Languages/Base/Injections/GutterInjection.php
+++ b/src/Languages/Base/Injections/GutterInjection.php
@@ -62,7 +62,7 @@ final class GutterInjection implements Injection
             $gutterClass = 'hl-gutter' . ($hasClasses ? ' ' . $hasClasses : '');
 
             $lines[$i] = sprintf(
-                Escape::tokens('<span class="%s">%s</span> %s'),
+                Escape::tokens('<span class="%s">%s</span>%s'),
                 $gutterClass,
                 str_pad(
                     string: (string) $gutterNumber,

--- a/src/Languages/Base/Injections/GutterInjection.php
+++ b/src/Languages/Base/Injections/GutterInjection.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tempest\Highlight\Languages\Base\Injections;
 
 use Tempest\Highlight\Escape;
-use Tempest\Highlight\TerminalTheme;
 use Tempest\Highlight\Highlighter;
 use Tempest\Highlight\Injection;
 use Tempest\Highlight\ParsedInjection;
+use Tempest\Highlight\TerminalTheme;
 
 final class GutterInjection implements Injection
 {

--- a/src/Languages/Base/Injections/GutterInjection.php
+++ b/src/Languages/Base/Injections/GutterInjection.php
@@ -63,13 +63,14 @@ final class GutterInjection implements Injection
             $gutterClass = 'hl-gutter' . ($hasClasses ? ' ' . $hasClasses : '');
 
             $lines[$i] = sprintf(
-                Escape::tokens('<span class="%s">%s</span>'.($highlighter->getTheme() instanceof TerminalTheme ? ' ' : '').'%s'),
+                Escape::tokens('<span class="%s">%s</span>%s%s'),
                 $gutterClass,
                 str_pad(
                     string: (string) $gutterNumber,
                     length: $gutterWidth,
                     pad_type: STR_PAD_LEFT,
                 ),
+                $highlighter->getTheme() instanceof TerminalTheme ? ' ' : '',
                 $line,
             );
         }

--- a/src/Languages/Base/Injections/GutterInjection.php
+++ b/src/Languages/Base/Injections/GutterInjection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Highlight\Languages\Base\Injections;
 
 use Tempest\Highlight\Escape;
+use Tempest\Highlight\TerminalTheme;
 use Tempest\Highlight\Highlighter;
 use Tempest\Highlight\Injection;
 use Tempest\Highlight\ParsedInjection;
@@ -62,7 +63,7 @@ final class GutterInjection implements Injection
             $gutterClass = 'hl-gutter' . ($hasClasses ? ' ' . $hasClasses : '');
 
             $lines[$i] = sprintf(
-                Escape::tokens('<span class="%s">%s</span>%s'),
+                Escape::tokens('<span class="%s">%s</span>'.($highlighter->getTheme() instanceof TerminalTheme ? ' ' : '').'%s'),
                 $gutterClass,
                 str_pad(
                     string: (string) $gutterNumber,

--- a/src/Themes/Css/andromeeda.css
+++ b/src/Themes/Css/andromeeda.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/aurora-x.css
+++ b/src/Themes/Css/aurora-x.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/ayu-dark.css
+++ b/src/Themes/Css/ayu-dark.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/catppuccin-frappe.css
+++ b/src/Themes/Css/catppuccin-frappe.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/catppuccin-latte.css
+++ b/src/Themes/Css/catppuccin-latte.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/catppuccin-macchiato.css
+++ b/src/Themes/Css/catppuccin-macchiato.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/catppuccin-mocha.css
+++ b/src/Themes/Css/catppuccin-mocha.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/dark-plus.css
+++ b/src/Themes/Css/dark-plus.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/dracula-soft.css
+++ b/src/Themes/Css/dracula-soft.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/dracula.css
+++ b/src/Themes/Css/dracula.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/github-dark-default.css
+++ b/src/Themes/Css/github-dark-default.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/github-dark-dimmed.css
+++ b/src/Themes/Css/github-dark-dimmed.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/github-dark.css
+++ b/src/Themes/Css/github-dark.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/github-light-default.css
+++ b/src/Themes/Css/github-light-default.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/github-light.css
+++ b/src/Themes/Css/github-light.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/highlight-light-lite.css
+++ b/src/Themes/Css/highlight-light-lite.css
@@ -64,6 +64,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/houston.css
+++ b/src/Themes/Css/houston.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/inspired-github.css
+++ b/src/Themes/Css/inspired-github.css
@@ -81,6 +81,7 @@ pre, code {
     font-size: 0.9em;
     color: #b3b3b3;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/light-plus.css
+++ b/src/Themes/Css/light-plus.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/material-theme-darker.css
+++ b/src/Themes/Css/material-theme-darker.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/material-theme-lighter.css
+++ b/src/Themes/Css/material-theme-lighter.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/material-theme-ocean.css
+++ b/src/Themes/Css/material-theme-ocean.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/material-theme-palenight.css
+++ b/src/Themes/Css/material-theme-palenight.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/material-theme.css
+++ b/src/Themes/Css/material-theme.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/min-dark.css
+++ b/src/Themes/Css/min-dark.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/min-light.css
+++ b/src/Themes/Css/min-light.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/monokai.css
+++ b/src/Themes/Css/monokai.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/night-owl.css
+++ b/src/Themes/Css/night-owl.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/nord.css
+++ b/src/Themes/Css/nord.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/one-dark-pro.css
+++ b/src/Themes/Css/one-dark-pro.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/poimandres.css
+++ b/src/Themes/Css/poimandres.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/red.css
+++ b/src/Themes/Css/red.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/rose-pine-dawn.css
+++ b/src/Themes/Css/rose-pine-dawn.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/rose-pine-moon.css
+++ b/src/Themes/Css/rose-pine-moon.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/rose-pine.css
+++ b/src/Themes/Css/rose-pine.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/slack-dark.css
+++ b/src/Themes/Css/slack-dark.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/slack-ochin.css
+++ b/src/Themes/Css/slack-ochin.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/solarized-dark.css
+++ b/src/Themes/Css/solarized-dark.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/solarized-light.css
+++ b/src/Themes/Css/solarized-light.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/synthwave-84.css
+++ b/src/Themes/Css/synthwave-84.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/tokyo-night.css
+++ b/src/Themes/Css/tokyo-night.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/vesper.css
+++ b/src/Themes/Css/vesper.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/vitesse-black.css
+++ b/src/Themes/Css/vitesse-black.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/vitesse-dark.css
+++ b/src/Themes/Css/vitesse-dark.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/src/Themes/Css/vitesse-light.css
+++ b/src/Themes/Css/vitesse-light.css
@@ -72,6 +72,7 @@ pre, code {
     font-size: 0.9em;
     color: #555;
     padding: 0 1ch;
+    margin-right: 1ch;
     user-select: none;
 }
 

--- a/tests/CommonMark/CodeBlockRendererTest.php
+++ b/tests/CommonMark/CodeBlockRendererTest.php
@@ -53,7 +53,7 @@ class Foo {}
 TXT;
 
         $expected = <<<'TXT'
-<pre data-lang="php" class="notranslate"><span class="hl-gutter">10</span> <span class="hl-keyword">class</span> <span class="hl-type">Foo</span> {}</pre>
+<pre data-lang="php" class="notranslate"><span class="hl-gutter">10</span><span class="hl-keyword">class</span> <span class="hl-type">Foo</span> {}</pre>
 
 TXT;
 

--- a/tests/Languages/Base/Injections/GutterInjectionTest.php
+++ b/tests/Languages/Base/Injections/GutterInjectionTest.php
@@ -32,22 +32,22 @@ foreach ($lines as $i => $line) {
 TXT;
 
         $expected = <<<'TXT'
-<span class="hl-gutter">  10</span> <span class="hl-keyword">foreach</span> (<span class="hl-variable">$lines</span> <span class="hl-keyword">as</span> <span class="hl-variable">$i</span> =&gt; <span class="hl-variable">$line</span>) {
-<span class="hl-gutter">  11</span>     <span class="hl-variable">$gutterNumber</span> = <span class="hl-variable">$gutterNumbers</span>[<span class="hl-variable">$i</span>];
-<span class="hl-gutter">  12</span> 
-<span class="hl-gutter">  13</span>     <span class="hl-variable">$gutterClass</span> = '<span class="hl-value">hl-gutter </span>' . (<span class="hl-variable">$this</span>-&gt;<span class="hl-property">classes</span>[<span class="hl-variable">$i</span> + 1] ?? '<span class="hl-value"></span>');
-<span class="hl-gutter hl-gutter-addition">14 +</span> <span class="hl-addition"></span>
-<span class="hl-gutter hl-gutter-addition">15 +</span> <span class="hl-addition">    <span class="hl-variable">$lines</span>[<span class="hl-variable">$i</span>] = <span class="hl-property">sprintf</span>(</span>
-<span class="hl-gutter hl-gutter-addition">16 +</span> <span class="hl-addition">        <span class="hl-type">Escape</span>::<span class="hl-property">tokens</span>('<span class="hl-value">&lt;span class=&quot;%s&quot;&gt;%s&lt;/span&gt;%s</span>'),</span>
-<span class="hl-gutter">  17</span>         <span class="hl-variable">$gutterClass</span>,
-<span class="hl-gutter">  18</span>         <span class="hl-property">str_pad</span>(
-<span class="hl-gutter hl-gutter-deletion">19 -</span>             <span class="hl-property">string</span>: <span class="hl-deletion"><span class="hl-variable">$gutterNumber</span></span>,
-<span class="hl-gutter">  20</span>             <span class="hl-property">length</span>: <span class="hl-variable">$gutterWidth</span>,
-<span class="hl-gutter">  21</span>             <span class="hl-property">pad_type</span>: <span class="hl-property">STR_PAD_LEFT</span>,
-<span class="hl-gutter">  22</span>         ),
-<span class="hl-gutter">  23</span>         <span class="hl-variable">$line</span>,
-<span class="hl-gutter">  24</span>     );
-<span class="hl-gutter">  25</span> }
+<span class="hl-gutter">  10</span><span class="hl-keyword">foreach</span> (<span class="hl-variable">$lines</span> <span class="hl-keyword">as</span> <span class="hl-variable">$i</span> =&gt; <span class="hl-variable">$line</span>) {
+<span class="hl-gutter">  11</span>    <span class="hl-variable">$gutterNumber</span> = <span class="hl-variable">$gutterNumbers</span>[<span class="hl-variable">$i</span>];
+<span class="hl-gutter">  12</span>
+<span class="hl-gutter">  13</span>    <span class="hl-variable">$gutterClass</span> = '<span class="hl-value">hl-gutter </span>' . (<span class="hl-variable">$this</span>-&gt;<span class="hl-property">classes</span>[<span class="hl-variable">$i</span> + 1] ?? '<span class="hl-value"></span>');
+<span class="hl-gutter hl-gutter-addition">14 +</span><span class="hl-addition"></span>
+<span class="hl-gutter hl-gutter-addition">15 +</span><span class="hl-addition">    <span class="hl-variable">$lines</span>[<span class="hl-variable">$i</span>] = <span class="hl-property">sprintf</span>(</span>
+<span class="hl-gutter hl-gutter-addition">16 +</span><span class="hl-addition">        <span class="hl-type">Escape</span>::<span class="hl-property">tokens</span>('<span class="hl-value">&lt;span class=&quot;%s&quot;&gt;%s&lt;/span&gt;%s</span>'),</span>
+<span class="hl-gutter">  17</span>        <span class="hl-variable">$gutterClass</span>,
+<span class="hl-gutter">  18</span>        <span class="hl-property">str_pad</span>(
+<span class="hl-gutter hl-gutter-deletion">19 -</span>            <span class="hl-property">string</span>: <span class="hl-deletion"><span class="hl-variable">$gutterNumber</span></span>,
+<span class="hl-gutter">  20</span>            <span class="hl-property">length</span>: <span class="hl-variable">$gutterWidth</span>,
+<span class="hl-gutter">  21</span>            <span class="hl-property">pad_type</span>: <span class="hl-property">STR_PAD_LEFT</span>,
+<span class="hl-gutter">  22</span>        ),
+<span class="hl-gutter">  23</span>        <span class="hl-variable">$line</span>,
+<span class="hl-gutter">  24</span>    );
+<span class="hl-gutter">  25</span>}
 TXT;
         $highlighter = (new Highlighter())->withGutter(10);
 
@@ -65,11 +65,11 @@ other: foo
 TXT;
 
         $expected = <<<'TXT'
-<span class="hl-gutter">  10</span> <span class="hl-property">on</span>:
-<span class="hl-gutter">  11</span>   <span class="hl-property">pull_request</span>:
-<span class="hl-gutter">  12</span>     <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review]
-<span class="hl-gutter hl-gutter-addition">13 +</span> <span class="hl-addition"> <span class="hl-property">pull_request_target</span>: </span>
-<span class="hl-gutter">  14</span> <span class="hl-property">other</span>: foo
+<span class="hl-gutter">  10</span><span class="hl-property">on</span>:
+<span class="hl-gutter">  11</span>  <span class="hl-property">pull_request</span>:
+<span class="hl-gutter">  12</span>    <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review]
+<span class="hl-gutter hl-gutter-addition">13 +</span><span class="hl-addition"> <span class="hl-property">pull_request_target</span>: </span>
+<span class="hl-gutter">  14</span><span class="hl-property">other</span>: foo
 TXT;
 
         $highlighter = (new Highlighter())->withGutter(10);
@@ -91,14 +91,14 @@ other: foo
 TXT;
 
         $expected = <<<'TXT'
-<span class="hl-gutter">  10</span> <span class="hl-property">on</span>:
-<span class="hl-gutter">  11</span>   <span class="hl-property">pull_request</span>:
-<span class="hl-gutter">  12</span>     <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review]
-<span class="hl-gutter hl-gutter-addition">13 +</span> <span class="hl-addition"> <span class="hl-property">pull_request_target</span>: </span>
-<span class="hl-gutter hl-gutter-addition">14 +</span> <span class="hl-addition">   <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review] </span>
-<span class="hl-gutter hl-gutter-addition">15 +</span> <span class="hl-addition">   <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review] </span>
-<span class="hl-gutter hl-gutter-addition">16 +</span> <span class="hl-addition">   <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review] </span>
-<span class="hl-gutter">  17</span> <span class="hl-property">other</span>: foo
+<span class="hl-gutter">  10</span><span class="hl-property">on</span>:
+<span class="hl-gutter">  11</span>  <span class="hl-property">pull_request</span>:
+<span class="hl-gutter">  12</span>    <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review]
+<span class="hl-gutter hl-gutter-addition">13 +</span><span class="hl-addition"> <span class="hl-property">pull_request_target</span>: </span>
+<span class="hl-gutter hl-gutter-addition">14 +</span><span class="hl-addition">   <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review] </span>
+<span class="hl-gutter hl-gutter-addition">15 +</span><span class="hl-addition">   <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review] </span>
+<span class="hl-gutter hl-gutter-addition">16 +</span><span class="hl-addition">   <span class="hl-property">types</span>: [opened, synchronize, reopened, ready_for_review] </span>
+<span class="hl-gutter">  17</span><span class="hl-property">other</span>: foo
 TXT;
 
         $highlighter = (new Highlighter())->withGutter(10);


### PR DESCRIPTION
Assume I have the following code block:

<img width="284" alt="code-block" src="https://github.com/user-attachments/assets/20ef0463-14dd-4b8b-b2aa-d6d284524fcf">

With gutter enabled, when I drag the code and paste it to an editor, it will be as follows:

<img width="402" alt="code-block-2" src="https://github.com/user-attachments/assets/8b6b9923-0ea7-4981-a3b7-a9f1eeba234b">

As you can see, there is extra space at the start of each line.

This PR removes the extra space and adds 1 char right margin to gutter elements. This output will be as follows:

<img width="376" alt="code-block-3" src="https://github.com/user-attachments/assets/8aedd216-fed1-47df-b404-3bdd295ec530">