### PR TITLE
Fix for trimming code when using gutter

### DIFF
--- a/src/Languages/Base/Injections/GutterInjection.php
+++ b/src/Languages/Base/Injections/GutterInjection.php
@@ -34,7 +34,7 @@ final class GutterInjection implements Injection
 
     public function parse(string $content, Highlighter $highlighter): ParsedInjection
     {
-        $lines = preg_split('/\R/u', trim($content));
+        $lines = preg_split('/\R/u', trim($content, "\n"));
 
         $gutterNumbers = [];
         $longestGutterNumber = '';


### PR DESCRIPTION
When the gutter is enabled, the code is trimmed. Assume we have the following code block:

<img width="275" alt="trim-1" src="https://github.com/user-attachments/assets/6aa32968-af2c-407c-939d-5a9d86f39c6c">

Currently, it's rendered as follows:

<img width="308" alt="trim-2" src="https://github.com/user-attachments/assets/e59fa080-080b-44d5-be84-3e8331978b94">

This PR changes the way the code is getting trimmed when using gutter. Now only linefeeds (`\n`s) are being trimmed. The result will be as follows:

<img width="324" alt="trim-3" src="https://github.com/user-attachments/assets/fba0e92e-023a-49c0-b951-2e4e65b7e62a">