### PR TITLE
PHP Tags and Blade Namespaced Components

### DIFF
--- a/src/Languages/Blade/BladeLanguage.php
+++ b/src/Languages/Blade/BladeLanguage.php
@@ -9,6 +9,8 @@ use Tempest\Highlight\Languages\Blade\Injections\BladeKeywordInjection;
 use Tempest\Highlight\Languages\Blade\Injections\BladePhpInjection;
 use Tempest\Highlight\Languages\Blade\Injections\BladeRawEchoInjection;
 use Tempest\Highlight\Languages\Blade\Patterns\BladeCommentPattern;
+use Tempest\Highlight\Languages\Blade\Patterns\BladeComponentCloseTagPattern;
+use Tempest\Highlight\Languages\Blade\Patterns\BladeComponentOpenTagPattern;
 use Tempest\Highlight\Languages\Blade\Patterns\BladeKeywordPattern;
 use Tempest\Highlight\Languages\Html\HtmlLanguage;
 
@@ -34,6 +36,8 @@ class BladeLanguage extends HtmlLanguage
     {
         return [
             ...parent::getPatterns(),
+            new BladeComponentOpenTagPattern(),
+            new BladeComponentCloseTagPattern(),
             new BladeKeywordPattern(),
             new BladeCommentPattern(),
         ];

--- a/src/Languages/Blade/Patterns/BladeComponentCloseTagPattern.php
+++ b/src/Languages/Blade/Patterns/BladeComponentCloseTagPattern.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Highlight\Languages\Blade\Patterns;
+
+use Tempest\Highlight\IsPattern;
+use Tempest\Highlight\Pattern;
+use Tempest\Highlight\PatternTest;
+use Tempest\Highlight\Tokens\TokenTypeEnum;
+
+#[PatternTest(input: '</x-hello>', output: 'x-hello')]
+#[PatternTest(input: '</x-hello::world>', output: 'x-hello::world')]
+#[PatternTest(input: '</a>', output: 'a')]
+final readonly class BladeComponentCloseTagPattern implements Pattern
+{
+    use IsPattern;
+
+    public function getPattern(): string
+    {
+        return '<\/(?<match>[\w\-\:]+)';
+    }
+
+    public function getTokenType(): TokenTypeEnum
+    {
+        return TokenTypeEnum::KEYWORD;
+    }
+}

--- a/src/Languages/Blade/Patterns/BladeComponentCloseTagPattern.php
+++ b/src/Languages/Blade/Patterns/BladeComponentCloseTagPattern.php
@@ -9,16 +9,17 @@ use Tempest\Highlight\Pattern;
 use Tempest\Highlight\PatternTest;
 use Tempest\Highlight\Tokens\TokenTypeEnum;
 
+#[PatternTest(input: '</a>', output: 'a')]
 #[PatternTest(input: '</x-hello>', output: 'x-hello')]
 #[PatternTest(input: '</x-hello::world>', output: 'x-hello::world')]
-#[PatternTest(input: '</a>', output: 'a')]
+#[PatternTest(input: '</x-hello::world.lorem>', output: 'x-hello::world.lorem')]
 final readonly class BladeComponentCloseTagPattern implements Pattern
 {
     use IsPattern;
 
     public function getPattern(): string
     {
-        return '<\/(?<match>[\w\-\:]+)';
+        return '<\/(?<match>[\w\-\:\.]+)';
     }
 
     public function getTokenType(): TokenTypeEnum

--- a/src/Languages/Blade/Patterns/BladeComponentOpenTagPattern.php
+++ b/src/Languages/Blade/Patterns/BladeComponentOpenTagPattern.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Highlight\Languages\Blade\Patterns;
+
+use Tempest\Highlight\IsPattern;
+use Tempest\Highlight\Pattern;
+use Tempest\Highlight\PatternTest;
+use Tempest\Highlight\Tokens\TokenTypeEnum;
+
+#[PatternTest(input: '<x-hello attr="">', output: 'x-hello')]
+#[PatternTest(input: '<x-hello::world attr="">', output: 'x-hello::world')]
+#[PatternTest(input: '<a attr="">', output: 'a')]
+final readonly class BladeComponentOpenTagPattern implements Pattern
+{
+    use IsPattern;
+
+    public function getPattern(): string
+    {
+        return '<(?<match>[\w\-\:]+)';
+    }
+
+    public function getTokenType(): TokenTypeEnum
+    {
+        return TokenTypeEnum::KEYWORD;
+    }
+}

--- a/src/Languages/Blade/Patterns/BladeComponentOpenTagPattern.php
+++ b/src/Languages/Blade/Patterns/BladeComponentOpenTagPattern.php
@@ -9,16 +9,17 @@ use Tempest\Highlight\Pattern;
 use Tempest\Highlight\PatternTest;
 use Tempest\Highlight\Tokens\TokenTypeEnum;
 
+#[PatternTest(input: '<a attr="">', output: 'a')]
 #[PatternTest(input: '<x-hello attr="">', output: 'x-hello')]
 #[PatternTest(input: '<x-hello::world attr="">', output: 'x-hello::world')]
-#[PatternTest(input: '<a attr="">', output: 'a')]
+#[PatternTest(input: '<x-hello::world.lorem attr="">', output: 'x-hello::world.lorem')]
 final readonly class BladeComponentOpenTagPattern implements Pattern
 {
     use IsPattern;
 
     public function getPattern(): string
     {
-        return '<(?<match>[\w\-\:]+)';
+        return '<(?<match>[\w\-\:\.]+)';
     }
 
     public function getTokenType(): TokenTypeEnum

--- a/src/Languages/Php/Patterns/PhpCloseTagPattern.php
+++ b/src/Languages/Php/Patterns/PhpCloseTagPattern.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Highlight\Languages\Php\Patterns;
+
+use Tempest\Highlight\IsPattern;
+use Tempest\Highlight\Pattern;
+use Tempest\Highlight\PatternTest;
+use Tempest\Highlight\Tokens\TokenTypeEnum;
+
+#[PatternTest(input: '?>', output: '?>')]
+final readonly class PhpCloseTagPattern implements Pattern
+{
+    use IsPattern;
+
+    public function getPattern(): string
+    {
+        return '(?<match>\?\>+)';
+    }
+
+    public function getTokenType(): TokenTypeEnum
+    {
+        return TokenTypeEnum::KEYWORD;
+    }
+}

--- a/src/Languages/Php/Patterns/PhpOpenTagPattern.php
+++ b/src/Languages/Php/Patterns/PhpOpenTagPattern.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Highlight\Languages\Php\Patterns;
+
+use Tempest\Highlight\IsPattern;
+use Tempest\Highlight\Pattern;
+use Tempest\Highlight\PatternTest;
+use Tempest\Highlight\Tokens\TokenTypeEnum;
+
+#[PatternTest(input: '<?php', output: '<?php')]
+#[PatternTest(input: '<?=', output: '<?=')]
+final readonly class PhpOpenTagPattern implements Pattern
+{
+    use IsPattern;
+
+    public function getPattern(): string
+    {
+        return '(?<match>\<\?[=|php]+)';
+    }
+
+    public function getTokenType(): TokenTypeEnum
+    {
+        return TokenTypeEnum::KEYWORD;
+    }
+}

--- a/src/Languages/Php/PhpLanguage.php
+++ b/src/Languages/Php/PhpLanguage.php
@@ -34,6 +34,8 @@ use Tempest\Highlight\Languages\Php\Patterns\NamespacePattern;
 use Tempest\Highlight\Languages\Php\Patterns\NestedFunctionCallPattern;
 use Tempest\Highlight\Languages\Php\Patterns\NewObjectPattern;
 use Tempest\Highlight\Languages\Php\Patterns\OperatorPattern;
+use Tempest\Highlight\Languages\Php\Patterns\PhpCloseTagPattern;
+use Tempest\Highlight\Languages\Php\Patterns\PhpOpenTagPattern;
 use Tempest\Highlight\Languages\Php\Patterns\PropertyAccessPattern;
 use Tempest\Highlight\Languages\Php\Patterns\PropertyHookGetPattern;
 use Tempest\Highlight\Languages\Php\Patterns\PropertyHookSetParameterTypePattern;
@@ -76,6 +78,8 @@ class PhpLanguage extends BaseLanguage
         return [
             ...parent::getPatterns(),
 
+            new PhpOpenTagPattern(),
+            new PhpCloseTagPattern(),
             new UseFunctionNamePattern(),
             new UseFunctionPattern(),
             new ClassNamePattern(),


### PR DESCRIPTION
### Changed

- Fixes matching Blade's namespaced components

### Added

- Adds the PHP tags as keywords. 

---

<details>
<summary>PHP Tags before/after</summary>

Before:
![image](https://github.com/user-attachments/assets/8d1c1b5d-c54a-492b-8072-f5b464bfa5ff)

After:
![image](https://github.com/user-attachments/assets/f0d5c740-6e0d-4e84-b325-bc1857b9978d)

---

Short Tags:

Before:
![image](https://github.com/user-attachments/assets/0ecc1fb5-589c-4717-a613-684e5063c994)

After:
![image](https://github.com/user-attachments/assets/6d2e6fc1-20c5-473b-b3c0-6a005603b8c8)

</details>

<details>
<summary>Blade Components before/after</summary>

Before:
![image](https://github.com/user-attachments/assets/2a9a9887-7390-401a-9c01-cf7e830e32d2)

After:
![image](https://github.com/user-attachments/assets/4b6f5304-5bfe-4655-bb3f-c436b51ef9b6)

</details>

I have made everything keyword, but not sure if anything else would better describe it. Let me know if y'all think something else would be more adequate.