### PR TITLE
Add support for PHP shell-style comments

### DIFF
--- a/src/Languages/Php/Patterns/SinglelineCommentPattern.php
+++ b/src/Languages/Php/Patterns/SinglelineCommentPattern.php
@@ -14,7 +14,7 @@ final readonly class SinglelineCommentPattern implements Pattern
 
     public function getPattern(): string
     {
-        return '(?<match>\/\/(.)*)';
+        return '(?<match>(?:\/\/|#[^\[])(.)*)';
     }
 
     public function getTokenType(): TokenTypeEnum

--- a/tests/Languages/Php/Patterns/SinglelineDocCommentPatternTest.php
+++ b/tests/Languages/Php/Patterns/SinglelineDocCommentPatternTest.php
@@ -19,5 +19,23 @@ class SinglelineDocCommentPatternTest extends TestCase
             content: '$bar // foo',
             expected: '// foo',
         );
+
+        $this->assertMatches(
+            pattern: new SinglelineCommentPattern(),
+            content: '$bar # foo',
+            expected: '# foo',
+        );
+
+        $this->assertMatches(
+            pattern: new SinglelineCommentPattern(),
+            content: '$bar #[IncompleteAttribute',
+            expected: null,
+        );
+
+        $this->assertMatches(
+            pattern: new SinglelineCommentPattern(),
+            content: '$bar #[Attribute]',
+            expected: null,
+        );
     }
 }


### PR DESCRIPTION
This PR ensures shell-style comments (`# with a hash`) are handled correctly. It ignores attributes, even when the closing `]` is missing.

**Before**
![Before](https://github.com/user-attachments/assets/2ec6343e-deba-48cc-b575-4fb37054ffe0)

**After**
![After](https://github.com/user-attachments/assets/1fec0161-e0db-4157-820d-7725b8f87e57)
