### PR TITLE
feat: add string literal unions typescript generic parsing and test

### DIFF
--- a/src/Languages/TypeScript/Patterns/TsGenericPattern.php
+++ b/src/Languages/TypeScript/Patterns/TsGenericPattern.php
@@ -14,7 +14,7 @@ final class TsGenericPattern implements Pattern
 
     public function getPattern(): string
     {
-        return '/(?<=\w)(?<match><[A-Z][\w\s,\.\[\]]*>)/';
+        return '/(?<=\w)(?<match><[A-Z\'"][\w\s,\.\[\]\'"|]*>)/';
     }
 
     public function getTokenType(): TokenTypeEnum

--- a/tests/Languages/TypeScript/TypeScriptLanguageTest.php
+++ b/tests/Languages/TypeScript/TypeScriptLanguageTest.php
@@ -72,6 +72,14 @@ class TypeScriptLanguageTest extends TestCase
                 '<span class="hl-keyword">class</span> <span class="hl-type">Service</span><span class="hl-generic">&lt;K, V <span class="hl-keyword">extends</span> Base&gt;</span> {}',
             ],
             [
+                "let filter: State<'all' | 'active' | 'done'> = 'all';",
+                '<span class="hl-keyword">let</span> <span class="hl-property">filter</span>: <span class="hl-type">State</span><span class="hl-generic">&lt;<span class="hl-value">\'all\'</span> | <span class="hl-value">\'active\'</span> | <span class="hl-value">\'done\'</span>&gt;</span> = <span class="hl-value">\'all\'</span>;',
+            ],
+            [
+                'let filter: State<"all" | "active" | "done"> = "all";',
+                '<span class="hl-keyword">let</span> <span class="hl-property">filter</span>: <span class="hl-type">State</span><span class="hl-generic">&lt;<span class="hl-value">&quot;all&quot;</span> | <span class="hl-value">&quot;active&quot;</span> | <span class="hl-value">&quot;done&quot;</span>&gt;</span> = <span class="hl-value">&quot;all&quot;</span>;',
+            ],
+            [
                 <<<'TXT'
                 @Component({ selector: 'x' })
                 class Foo {}


### PR DESCRIPTION
Currently, I'm trying to add Svelte support to this package.

I really appreciate the TypeScript language support, so I can reuse it directly in Svelte.

I noticed that string-literal unions are missing from the generic pattern:

```typescript
let filter: State<'all' | 'active' | 'done'> = 'all';
```

So I changed the generic regex pattern slightly:

```php
// from
return '/(?<=\w)(?<match><[A-Z][\w\s,\.\[\]]*>)/';

// to
return '/(?<=\w)(?<match><[A-Z\'"][\w\s,\.\[\]\'"|]*>)/';
```